### PR TITLE
state: parallelize side-tx requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/tendermint/tm-db v0.2.0
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	golang.org/x/net v0.0.0-20190628185345-da137c7871d7
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7 // indirect
 	golang.org/x/text v0.3.2 // indirect
 	google.golang.org/grpc v1.23.1

--- a/go.sum
+++ b/go.sum
@@ -542,6 +542,8 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/state/execution.go
+++ b/state/execution.go
@@ -375,6 +375,8 @@ func execBlockOnProxyApp(
 		resp := make(chan error, len(block.Txs))
 		executions := 0
 
+		logger.Debug("[Peppermint] Executing side-tx", "number of txs", len(block.Txs))
+
 		// Run side-txs of block.
 		for txIndex, tx := range block.Txs {
 			txRes := abciResponses.DeliverTx[txIndex]
@@ -392,20 +394,22 @@ func execBlockOnProxyApp(
 
 		count := 0
 		done := make(chan bool, 1)
-	WaitForCallback:
-		for {
-			select {
-			case err := <-resp:
-				// return when we have 1st non-nill error
-				if err != nil {
-					return nil, nil, err
+		if executions > 0 {
+		WaitForCallback:
+			for {
+				select {
+				case err := <-resp:
+					// return when we have 1st non-nill error
+					if err != nil {
+						return nil, nil, err
+					}
+					count++
+					if count == executions {
+						done <- true
+					}
+				case <-done:
+					break WaitForCallback
 				}
-				count++
-				if count == executions {
-					done <- true
-				}
-			case <-done:
-				break WaitForCallback
 			}
 		}
 	}

--- a/state/execution.go
+++ b/state/execution.go
@@ -371,16 +371,41 @@ func execBlockOnProxyApp(
 		}
 		proxyAppConn.SetResponseCallback(proxySideCb)
 
+		// create channel for side-tx error response
+		resp := make(chan error, len(block.Txs))
+		executions := 0
+
 		// Run side-txs of block.
 		for txIndex, tx := range block.Txs {
 			txRes := abciResponses.DeliverTx[txIndex]
 
 			// execute side-tx only if tx is valid
 			if txRes.Code == abci.CodeTypeOK {
-				proxyAppConn.DeliverSideTxAsync(abci.RequestDeliverSideTx{Tx: tx})
-				if err := proxyAppConn.Error(); err != nil {
+				// execute the tx in a go routine and wait for the result
+				go func() {
+					proxyAppConn.DeliverSideTxAsync(abci.RequestDeliverSideTx{Tx: tx})
+					resp <- proxyAppConn.Error()
+				}()
+				executions++
+			}
+		}
+
+		count := 0
+		done := make(chan bool, 1)
+	WaitForCallback:
+		for {
+			select {
+			case err := <-resp:
+				// return when we have 1st non-nill error
+				if err != nil {
 					return nil, nil, err
 				}
+				count++
+				if count == executions {
+					done <- true
+				}
+			case <-done:
+				break WaitForCallback
 			}
 		}
 	}

--- a/state/execution.go
+++ b/state/execution.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/tendermint/tendermint/proxy"
 	"github.com/tendermint/tendermint/types"
 	dbm "github.com/tendermint/tm-db"
+	"golang.org/x/sync/errgroup"
 )
 
 //-----------------------------------------------------------------------------
@@ -371,11 +373,10 @@ func execBlockOnProxyApp(
 		}
 		proxyAppConn.SetResponseCallback(proxySideCb)
 
-		// create channel for side-tx error response
-		resp := make(chan error, len(block.Txs))
-		executions := 0
+		logger.Debug("[Peppermint] Delivering side-tx", "number of txs", len(block.Txs))
 
-		logger.Debug("[Peppermint] Executing side-tx", "number of txs", len(block.Txs))
+		// Creating an error group.
+		group, _ := errgroup.WithContext(context.Background())
 
 		// Run side-txs of block.
 		for txIndex, tx := range block.Txs {
@@ -383,34 +384,20 @@ func execBlockOnProxyApp(
 
 			// execute side-tx only if tx is valid
 			if txRes.Code == abci.CodeTypeOK {
-				// execute the tx in a go routine and wait for the result
-				go func() {
-					proxyAppConn.DeliverSideTxAsync(abci.RequestDeliverSideTx{Tx: tx})
-					resp <- proxyAppConn.Error()
-				}()
-				executions++
+				// execute the tx in a go routine and return the result of error
+				func(tx types.Tx) {
+					group.Go(func() error {
+						proxyAppConn.DeliverSideTxAsync(abci.RequestDeliverSideTx{Tx: tx})
+						return proxyAppConn.Error()
+					})
+				}(tx)
 			}
 		}
 
-		count := 0
-		done := make(chan bool, 1)
-		if executions > 0 {
-		WaitForCallback:
-			for {
-				select {
-				case err := <-resp:
-					// return when we have 1st non-nill error
-					if err != nil {
-						return nil, nil, err
-					}
-					count++
-					if count == executions {
-						done <- true
-					}
-				case <-done:
-					break WaitForCallback
-				}
-			}
+		// This will wait for all the routines to finish and also helps
+		// in gracefull shutdown in case any of it fails.
+		if err := group.Wait(); err != nil {
+			return nil, nil, err
 		}
 	}
 


### PR DESCRIPTION
This PR attempts to perform the sequence of side-tx verification RPC calls (to eth and bor chain) in parallel.

The performance results after testing on our validation nodes (on matic mainnet) pre and post the change are mentioned below: 
 
|Number of side transactions|execution time (pre)|execution time (post)|percent improvement|
|---|---|---|---|
|9|759.341783ms|420.528839ms|44.62 %|
|8|778.619694ms|335.895929ms|56.86 %|
|7|579.639199ms|423.518429ms|26.93 %|
|6|453.171626ms|271.318678ms|40.13 %|
|5|768.574098ms|247.92161ms|67.74 %|
|4|329.764555ms|220.010653ms|33.28 %|
|2|159.461362ms|111.296395ms|30.20 %|

Note these results are from different nodes and some external factors like the difference in delay of RPC calls may affect. 

Linear: [POS 194 - Parallelize requests to rootchain and bor](https://linear.app/matic/issue/POS-194/parallelize-requests-to-rootchain-and-bor)