### PR TITLE
Change log level tag from a single character to a full word

### DIFF
--- a/libs/log/tmfmt_logger.go
+++ b/libs/log/tmfmt_logger.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 	"time"
 
@@ -85,13 +86,13 @@ func (l tmfmtLogger) Log(keyvals ...interface{}) error {
 	// Form a custom Tendermint line
 	//
 	// Example:
-	//     D[2016-05-02|11:06:44.322]   Stopping AddrBook (ignoring: already stopped)
+	//     DEBUG[2016-05-02|11:06:44.322]   Stopping AddrBook (ignoring: already stopped)
 	//
 	// Description:
-	//     D										- first character of the level, uppercase (ASCII only)
+	//     DEBUG						- log level, uppercase
 	//     [2016-05-02|11:06:44.322]    - our time format (see https://golang.org/src/time/format.go)
 	//     Stopping ...					- message
-	enc.buf.WriteString(fmt.Sprintf("%c[%s] %-44s ", lvl[0]-32, time.Now().Format("2006-01-02|15:04:05.000"), msg))
+	enc.buf.WriteString(fmt.Sprintf("%-5s[%s] %-44s ", strings.ToUpper(lvl), time.Now().Format("2006-01-02|15:04:05.000"), msg))
 
 	if module != unknown {
 		enc.buf.WriteString("module=" + module + " ")

--- a/libs/log/tmfmt_logger_test.go
+++ b/libs/log/tmfmt_logger_test.go
@@ -21,37 +21,37 @@ func TestTMFmtLogger(t *testing.T) {
 	if err := logger.Log("hello", "world"); err != nil {
 		t.Fatal(err)
 	}
-	assert.Regexp(t, regexp.MustCompile(`N\[.+\] unknown \s+ hello=world\n$`), buf.String())
+	assert.Regexp(t, regexp.MustCompile(`NONE \[.+\] unknown \s+ hello=world\n$`), buf.String())
 
 	buf.Reset()
 	if err := logger.Log("a", 1, "err", errors.New("error")); err != nil {
 		t.Fatal(err)
 	}
-	assert.Regexp(t, regexp.MustCompile(`N\[.+\] unknown \s+ a=1 err=error\n$`), buf.String())
+	assert.Regexp(t, regexp.MustCompile(`NONE \[.+\] unknown \s+ a=1 err=error\n$`), buf.String())
 
 	buf.Reset()
 	if err := logger.Log("std_map", map[int]int{1: 2}, "my_map", mymap{0: 0}); err != nil {
 		t.Fatal(err)
 	}
-	assert.Regexp(t, regexp.MustCompile(`N\[.+\] unknown \s+ std_map=map\[1:2\] my_map=special_behavior\n$`), buf.String())
+	assert.Regexp(t, regexp.MustCompile(`NONE \[.+\] unknown \s+ std_map=map\[1:2\] my_map=special_behavior\n$`), buf.String())
 
 	buf.Reset()
 	if err := logger.Log("level", "error"); err != nil {
 		t.Fatal(err)
 	}
-	assert.Regexp(t, regexp.MustCompile(`E\[.+\] unknown \s+\n$`), buf.String())
+	assert.Regexp(t, regexp.MustCompile(`ERROR\[.+\] unknown \s+\n$`), buf.String())
 
 	buf.Reset()
 	if err := logger.Log("_msg", "Hello"); err != nil {
 		t.Fatal(err)
 	}
-	assert.Regexp(t, regexp.MustCompile(`N\[.+\] Hello \s+\n$`), buf.String())
+	assert.Regexp(t, regexp.MustCompile(`NONE \[.+\] Hello \s+\n$`), buf.String())
 
 	buf.Reset()
 	if err := logger.Log("module", "main", "module", "crypto", "module", "wire"); err != nil {
 		t.Fatal(err)
 	}
-	assert.Regexp(t, regexp.MustCompile(`N\[.+\] unknown \s+module=wire\s+\n$`), buf.String())
+	assert.Regexp(t, regexp.MustCompile(`NONE \[.+\] unknown \s+module=wire\s+\n$`), buf.String())
 }
 
 func BenchmarkTMFmtLoggerSimple(b *testing.B) {


### PR DESCRIPTION
This will change logging format from:

D[2016-05-02|11:06:44.322]

to:

DEBUG[2016-05-02|11:06:44.322]

The purpose is to unify the logging with bor.
