### PR TITLE
consensus,scripts,state,store,types: change PartSetHeader total to uint32

### DIFF
--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -212,7 +212,7 @@ func sendProposalAndParts(height int64, round int, cs *ConsensusState, peer p2p.
 	peer.Send(DataChannel, cdc.MustMarshalBinaryBare(msg))
 
 	// parts
-	for i := 0; i < parts.Total(); i++ {
+	for i := 0; i < int(parts.Total()); i++ {
 		part := parts.GetPart(i)
 		msg := &BlockPartMessage{
 			Height: height, // This tells peer that this part applies to us.

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -688,7 +688,7 @@ func TestNewValidBlockMessageValidateBasic(t *testing.T) {
 			"Empty BlockParts",
 		},
 		{
-			func(msg *NewValidBlockMessage) { msg.BlockParts = cmn.NewBitArray(types.MaxBlockPartsCount + 1) },
+			func(msg *NewValidBlockMessage) { msg.BlockParts = cmn.NewBitArray(int(types.MaxBlockPartsCount + 1)) },
 			"BlockParts bit array size 1602 not equal to BlockPartsHeader.Total 1",
 		},
 	}
@@ -774,7 +774,7 @@ func TestBlockPartMessageValidateBasic(t *testing.T) {
 	}
 
 	message := BlockPartMessage{Height: 0, Round: 0, Part: new(types.Part)}
-	message.Part.Index = -1
+	message.Part.Index = 1
 
 	assert.Equal(t, true, message.ValidateBasic() != nil, "Validate Basic had an unexpected result")
 }
@@ -825,7 +825,7 @@ func TestVoteSetMaj23MessageValidateBasic(t *testing.T) {
 	invalidBlockID := types.BlockID{
 		Hash: cmn.HexBytes{},
 		PartsHeader: types.PartSetHeader{
-			Total: -1,
+			Total: 1,
 			Hash:  cmn.HexBytes{},
 		},
 	}
@@ -873,7 +873,7 @@ func TestVoteSetBitsMessageValidateBasic(t *testing.T) {
 			msg.BlockID = types.BlockID{
 				Hash: cmn.HexBytes{},
 				PartsHeader: types.PartSetHeader{
-					Total: -1,
+					Total: 1,
 					Hash:  cmn.HexBytes{},
 				},
 			}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -429,7 +429,7 @@ func (cs *ConsensusState) SetProposalAndBlock(proposal *types.Proposal, block *t
 	if err := cs.SetProposal(proposal, peerID); err != nil {
 		return err
 	}
-	for i := 0; i < parts.Total(); i++ {
+	for i := 0; i < int(parts.Total()); i++ {
 		part := parts.GetPart(i)
 		if err := cs.AddProposalBlockPart(proposal.Height, proposal.Round, part, peerID); err != nil {
 			return err
@@ -785,7 +785,9 @@ func (cs *ConsensusState) handleTxsAvailable() {
 // Used internally by handleTimeout and handleMsg to make state transitions
 
 // Enter: `timeoutNewHeight` by startTime (commitTime+timeoutCommit),
-// 	or, if SkipTimeoutCommit==true, after receiving all precommits from (height,round-1)
+//
+//	or, if SkipTimeoutCommit==true, after receiving all precommits from (height,round-1)
+//
 // Enter: `timeoutPrecommits` after any +2/3 precommits from (height,round-1)
 // Enter: +2/3 precommits for nil at (height,round-1)
 // Enter: +2/3 prevotes any or +2/3 precommits for block or any from (height, round)
@@ -940,7 +942,7 @@ func (cs *ConsensusState) defaultDecideProposal(height int64, round int) {
 
 		// send proposal and block parts on internal msg queue
 		cs.sendInternalMessage(msgInfo{&ProposalMessage{proposal}, ""})
-		for i := 0; i < blockParts.Total(); i++ {
+		for i := 0; i < int(blockParts.Total()); i++ {
 			part := blockParts.GetPart(i)
 			cs.sendInternalMessage(msgInfo{&BlockPartMessage{cs.Height, cs.Round, part}, ""})
 		}

--- a/scripts/json2wal/main.go
+++ b/scripts/json2wal/main.go
@@ -48,7 +48,7 @@ func main() {
 	// the length of tendermint/wal/MsgInfo in the wal.json may exceed the defaultBufSize(4096) of bufio
 	// because of the byte array in BlockPart
 	// leading to unmarshal error: unexpected end of JSON input
-	br := bufio.NewReaderSize(f, 2*types.BlockPartSizeBytes)
+	br := bufio.NewReaderSize(f, int(2*types.BlockPartSizeBytes))
 	dec := cs.NewWALEncoder(walFile)
 
 	for {

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -20,9 +20,9 @@ import (
 )
 
 var (
-	chainID      = "execution_chain"
-	testPartSize = 65536
-	nTxsPerBlock = 10
+	chainID             = "execution_chain"
+	testPartSize uint32 = 65536
+	nTxsPerBlock        = 10
 )
 
 func TestApplyBlock(t *testing.T) {

--- a/store/store.go
+++ b/store/store.go
@@ -15,9 +15,9 @@ import (
 BlockStore is a simple low level store for blocks.
 
 There are three types of information stored:
- - BlockMeta:   Meta information about each block
- - Block part:  Parts of each block, aggregated w/ PartSet
- - Commit:      The commit part of each block, for gossiping precommit votes
+  - BlockMeta:   Meta information about each block
+  - Block part:  Parts of each block, aggregated w/ PartSet
+  - Commit:      The commit part of each block, for gossiping precommit votes
 
 Currently the precommit signatures are duplicated in the Block parts as
 well as the Commit.  In the future this may change, perhaps by moving
@@ -60,7 +60,7 @@ func (bs *BlockStore) LoadBlock(height int64) *types.Block {
 
 	var block = new(types.Block)
 	buf := []byte{}
-	for i := 0; i < blockMeta.BlockID.PartsHeader.Total; i++ {
+	for i := 0; i < int(blockMeta.BlockID.PartsHeader.Total); i++ {
 		part := bs.LoadBlockPart(height, i)
 		buf = append(buf, part.Bytes...)
 	}
@@ -140,9 +140,10 @@ func (bs *BlockStore) LoadSeenCommit(height int64) *types.Commit {
 // SaveBlock persists the given block, blockParts, and seenCommit to the underlying db.
 // blockParts: Must be parts of the block
 // seenCommit: The +2/3 precommits that were seen which committed at height.
-//             If all the nodes restart after committing a block,
-//             we need this to reload the precommits to catch-up nodes to the
-//             most recent height.  Otherwise they'd stall at H-1.
+//
+//	If all the nodes restart after committing a block,
+//	we need this to reload the precommits to catch-up nodes to the
+//	most recent height.  Otherwise they'd stall at H-1.
 func (bs *BlockStore) SaveBlock(block *types.Block, blockParts *types.PartSet, seenCommit *types.Commit) {
 	if block == nil {
 		panic("BlockStore can only save a non-nil block")
@@ -161,7 +162,7 @@ func (bs *BlockStore) SaveBlock(block *types.Block, blockParts *types.PartSet, s
 	bs.db.Set(calcBlockMetaKey(height), metaBytes)
 
 	// Save block parts
-	for i := 0; i < blockParts.Total(); i++ {
+	for i := 0; i < int(blockParts.Total()); i++ {
 		part := blockParts.GetPart(i)
 		bs.saveBlockPart(height, i, part)
 	}

--- a/types/block.go
+++ b/types/block.go
@@ -189,7 +189,7 @@ func (b *Block) Hash() cmn.HexBytes {
 // MakePartSet returns a PartSet containing parts of a serialized block.
 // This is the form in which the block is gossipped to peers.
 // CONTRACT: partSize is greater than zero.
-func (b *Block) MakePartSet(partSize int) *PartSet {
+func (b *Block) MakePartSet(partSize uint32) *PartSet {
 	if b == nil {
 		return nil
 	}

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -173,7 +173,7 @@ func makeBlockIDRandom() BlockID {
 	return BlockID{blockHash, blockPartsHeader}
 }
 
-func makeBlockID(hash []byte, partSetSize int, partSetHash []byte) BlockID {
+func makeBlockID(hash []byte, partSetSize uint32, partSetHash []byte) BlockID {
 	return BlockID{
 		Hash: hash,
 		PartsHeader: PartSetHeader{
@@ -261,7 +261,7 @@ func TestMaxHeaderBytes(t *testing.T) {
 		Time:               timestamp,
 		NumTxs:             math.MaxInt64,
 		TotalTxs:           math.MaxInt64,
-		LastBlockID:        makeBlockID(make([]byte, tmhash.Size), math.MaxInt64, make([]byte, tmhash.Size)),
+		LastBlockID:        makeBlockID(make([]byte, tmhash.Size), math.MaxInt32, make([]byte, tmhash.Size)),
 		LastCommitHash:     tmhash.Sum([]byte("last_commit_hash")),
 		DataHash:           tmhash.Sum([]byte("data_hash")),
 		ValidatorsHash:     tmhash.Sum([]byte("validators_hash")),
@@ -492,7 +492,7 @@ func TestBlockIDValidateBasic(t *testing.T) {
 	invalidBlockID := BlockID{
 		Hash: []byte{0},
 		PartsHeader: PartSetHeader{
-			Total: -1,
+			Total: 1,
 			Hash:  cmn.HexBytes{},
 		},
 	}

--- a/types/canonical.go
+++ b/types/canonical.go
@@ -19,7 +19,7 @@ type CanonicalBlockID struct {
 
 type CanonicalPartSetHeader struct {
 	Hash  cmn.HexBytes
-	Total int
+	Total uint32
 }
 
 type CanonicalProposal struct {

--- a/types/evidence_test.go
+++ b/types/evidence_test.go
@@ -97,8 +97,8 @@ func TestEvidenceList(t *testing.T) {
 
 func TestMaxEvidenceBytes(t *testing.T) {
 	val := NewMockPV()
-	blockID := makeBlockID(tmhash.Sum([]byte("blockhash")), math.MaxInt64, tmhash.Sum([]byte("partshash")))
-	blockID2 := makeBlockID(tmhash.Sum([]byte("blockhash2")), math.MaxInt64, tmhash.Sum([]byte("partshash")))
+	blockID := makeBlockID(tmhash.Sum([]byte("blockhash")), math.MaxInt32, tmhash.Sum([]byte("partshash")))
+	blockID2 := makeBlockID(tmhash.Sum([]byte("blockhash2")), math.MaxInt32, tmhash.Sum([]byte("partshash")))
 	const chainID = "mychain"
 	ev := &DuplicateVoteEvidence{
 		PubKey: secp256k1.GenPrivKey().PubKey(), // use secp because it's pubkey is longer
@@ -125,8 +125,8 @@ func randomDuplicatedVoteEvidence() *DuplicateVoteEvidence {
 
 func TestDuplicateVoteEvidenceValidation(t *testing.T) {
 	val := NewMockPV()
-	blockID := makeBlockID(tmhash.Sum([]byte("blockhash")), math.MaxInt64, tmhash.Sum([]byte("partshash")))
-	blockID2 := makeBlockID(tmhash.Sum([]byte("blockhash2")), math.MaxInt64, tmhash.Sum([]byte("partshash")))
+	blockID := makeBlockID(tmhash.Sum([]byte("blockhash")), math.MaxInt32, tmhash.Sum([]byte("partshash")))
+	blockID2 := makeBlockID(tmhash.Sum([]byte("blockhash2")), math.MaxInt32, tmhash.Sum([]byte("partshash")))
 	const chainID = "mychain"
 
 	testCases := []struct {

--- a/types/params.go
+++ b/types/params.go
@@ -13,7 +13,7 @@ const (
 	MaxBlockSizeBytes = 104857600 // 100MB
 
 	// BlockPartSizeBytes is the size of one block part.
-	BlockPartSizeBytes = 65536 // 64kB
+	BlockPartSizeBytes uint32 = 65536 // 64kB
 
 	// MaxBlockPartsCount is the maximum count of block parts.
 	MaxBlockPartsCount = (MaxBlockSizeBytes / BlockPartSizeBytes) + 1

--- a/types/part_set_test.go
+++ b/types/part_set_test.go
@@ -31,7 +31,7 @@ func TestBasicPartSet(t *testing.T) {
 	partSet2 := NewPartSetFromHeader(partSet.Header())
 
 	assert.True(t, partSet2.HasHeader(partSet.Header()))
-	for i := 0; i < partSet.Total(); i++ {
+	for i := 0; i < int(partSet.Total()); i++ {
 		part := partSet.GetPart(i)
 		//t.Logf("\n%v", part)
 		added, err := partSet2.AddPart(part)
@@ -92,7 +92,6 @@ func TestPartSetHeaderValidateBasic(t *testing.T) {
 		expectErr             bool
 	}{
 		{"Good PartSet", func(psHeader *PartSetHeader) {}, false},
-		{"Negative Total", func(psHeader *PartSetHeader) { psHeader.Total = -2 }, true},
 		{"Invalid Hash", func(psHeader *PartSetHeader) { psHeader.Hash = make([]byte, 1) }, true},
 	}
 	for _, tc := range testCases {
@@ -114,7 +113,6 @@ func TestPartValidateBasic(t *testing.T) {
 		expectErr    bool
 	}{
 		{"Good Part", func(pt *Part) {}, false},
-		{"Negative index", func(pt *Part) { pt.Index = -1 }, true},
 		{"Too big part", func(pt *Part) { pt.Bytes = make([]byte, BlockPartSizeBytes+1) }, true},
 		{"Too big proof", func(pt *Part) {
 			pt.Proof = merkle.SimpleProof{

--- a/types/proposal_test.go
+++ b/types/proposal_test.go
@@ -124,7 +124,7 @@ func TestProposalValidateBasic(t *testing.T) {
 			p.Signature = make([]byte, MaxSignatureSize+1)
 		}, true},
 	}
-	blockID := makeBlockID(tmhash.Sum([]byte("blockhash")), math.MaxInt64, tmhash.Sum([]byte("partshash")))
+	blockID := makeBlockID(tmhash.Sum([]byte("blockhash")), math.MaxInt32, tmhash.Sum([]byte("partshash")))
 
 	for _, tc := range testCases {
 		tc := tc

--- a/types/vote_set_test.go
+++ b/types/vote_set_test.go
@@ -167,7 +167,7 @@ func Test2_3MajorityRedux(t *testing.T) {
 
 	blockHash := crypto.CRandBytes(32)
 	blockPartsTotal := 123
-	blockPartsHeader := PartSetHeader{blockPartsTotal, crypto.CRandBytes(32)}
+	blockPartsHeader := PartSetHeader{uint32(blockPartsTotal), crypto.CRandBytes(32)}
 
 	voteProto := &Vote{
 		ValidatorAddress: nil, // NOTE: must fill in
@@ -211,7 +211,7 @@ func Test2_3MajorityRedux(t *testing.T) {
 	{
 		addr := privValidators[67].GetPubKey().Address()
 		vote := withValidator(voteProto, addr, 67)
-		blockPartsHeader := PartSetHeader{blockPartsTotal, crypto.CRandBytes(32)}
+		blockPartsHeader := PartSetHeader{uint32(blockPartsTotal), crypto.CRandBytes(32)}
 		_, err := signAddVote(privValidators[67], withBlockPartsHeader(vote, blockPartsHeader), voteSet)
 		if err != nil {
 			t.Error(err)
@@ -226,7 +226,7 @@ func Test2_3MajorityRedux(t *testing.T) {
 	{
 		addr := privValidators[68].GetPubKey().Address()
 		vote := withValidator(voteProto, addr, 68)
-		blockPartsHeader := PartSetHeader{blockPartsTotal + 1, blockPartsHeader.Hash}
+		blockPartsHeader := PartSetHeader{uint32(blockPartsTotal + 1), blockPartsHeader.Hash}
 		_, err := signAddVote(privValidators[68], withBlockPartsHeader(vote, blockPartsHeader), voteSet)
 		if err != nil {
 			t.Error(err)

--- a/types/vote_test.go
+++ b/types/vote_test.go
@@ -237,7 +237,7 @@ func TestMaxVoteBytes(t *testing.T) {
 		BlockID: BlockID{
 			Hash: tmhash.Sum([]byte("blockID_hash")),
 			PartsHeader: PartSetHeader{
-				Total: math.MaxInt64,
+				Total: math.MaxInt32,
 				Hash:  tmhash.Sum([]byte("blockID_part_set_header_hash")),
 			},
 		},


### PR DESCRIPTION
This PR selectively picks changes from tendermint/tendermint#4939 to change type of `total`/`Total` in `PartSet`/`PartSetHeader` from `int` to `uint32`