### PR TITLE
handle: start after data dir deletion

### DIFF
--- a/privval/file.go
+++ b/privval/file.go
@@ -213,6 +213,10 @@ func loadFilePV(keyFilePath, stateFilePath string, loadState bool) *FilePV {
 func LoadOrGenFilePV(keyFilePath, stateFilePath string) *FilePV {
 	var pv *FilePV
 	if cmn.FileExists(keyFilePath) {
+		if !cmn.FileExists(stateFilePath) {
+			pv = LoadFilePVEmptyState(keyFilePath, stateFilePath)
+			pv.Save()
+		}
 		pv = LoadFilePV(keyFilePath, stateFilePath)
 	} else {
 		pv = GenFilePV(keyFilePath, stateFilePath)


### PR DESCRIPTION
Handles the case in which the heimdall node fails to start after data dir is deleted because of the missing `priv_validator_state.json` file. Reported by devops team.